### PR TITLE
Add GitHub Actions workflow for Docker image publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Remove existing Docker image
+        run: |
+          docker rmi teodossidossev/mse2024-be:latest || true
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: teodossidossev/mse2024-be:latest
+          context: .
+          file: ./Dockerfile
+
+      - name: Log out of Docker Hub
+        if: always()
+        run: docker logout


### PR DESCRIPTION
A new GitHub Actions workflow has been added to build and publish Docker images when changes are pushed to the main branch. The workflow includes steps for checking out the code, logging into Docker Hub, removing the old Docker image, building and pushing the new Docker image, and then logging out of Docker Hub.