### PR TITLE
Add triggering of infra repository workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,3 +33,15 @@ jobs:
       - name: Log out of Docker Hub
         if: always()
         run: docker logout
+
+      - name: Trigger workflow in infra repository
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/:owner/:repo/dispatches
+          owner: teodossidossev
+          repo: ci-infra
+          event_type: trigger-uat-event
+          client_payload: '{"ref":"main","description":"Triggered from ci-backend"}'
+          mediaType: '{"previews": ["flash"]}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_INFRA_TOKEN }}


### PR DESCRIPTION
The CI workflow for publishing Docker images has been updated to trigger a separate workflow in the infra repository. This action is taken after successfully logging out of Docker Hub. The triggered workflow is identified by 'trigger-uat-event' in the 'ci-infra' repository owned by user 'teodossidossev'.